### PR TITLE
refactor(git): replace `checkout` by newer `switch`/`restore`

### DIFF
--- a/src/git/first-side/column1.md
+++ b/src/git/first-side/column1.md
@@ -16,7 +16,7 @@ Add &lt;file&gt; contents to the index
 `git add <file>`
 
 Remove &lt;file&gt; from the index
-`git reset <file>`
+`git restore --staged <file>`
 
 Add current contents of the index in a new commit
 `git commit -m 'subject' -m 'body'`

--- a/src/git/reverse/column1.md
+++ b/src/git/reverse/column1.md
@@ -1,7 +1,7 @@
 # Branch
 
 Create a new local branch and switch HEAD branch
-`git checkout -b newBranch`
+`git switch -c newBranch`
 
 List local branches
 `git branch`
@@ -23,9 +23,10 @@ List all operations on repository
 
 Discard all local changes in your working directory
 `git reset --hard HEAD`
+**Be careful: you may lose valuable work!**
 
 Discard local changes in a file
-`git checkout HEAD <file>`
+`git restore --staged --worktree <file>`
 
 Revert a commit (add a new commit with contrary changes)
 `git revert <commit>`


### PR DESCRIPTION
Since 2023, Git recommends using `git switch` and `git restore` over `git checkout` because it makes clearer what they do, and they have safer defaults.
See : https://github.blog/open-source/git/highlights-from-git-2-23/#experimental-alternatives-for-git-checkout
I offer to update your cheatsheet with these recommendations.