### PR TITLE
refactor(docker-compose): rename command to V2 (without hyphen)

### DIFF
--- a/src/docker-compose/first-side/column1.md
+++ b/src/docker-compose/first-side/column1.md
@@ -1,32 +1,32 @@
- docker-compose version: __1.27.0__ - Date: __June 2022__
+ docker compose version: __1.27.0__ - Date: __June 2022__
  
 # Info
 
-Show the docker-compose version  
-`docker-compose version`
+Show the docker compose version  
+`docker compose version`
 
 Display help and usage instructions for a command
-`docker-compose help`
+`docker compose help`
 
 # Manage containers
 
 Build, (re)create and start containers
-`docker-compose up [options] [SERVICE]`
+`docker compose up [options] [SERVICE]`
 
-  * Start all containers in background: `docker-compose up -d`
+  * Start all containers in background: `docker compose up -d`
 
 Stop containers and remove containers, networks, volumes, and images created.
-`docker-compose down [options]`
+`docker compose down [options]`
 
 Restart all stopped and running services
-`docker-compose restart [options] [SERVICE]`
+`docker compose restart [options] [SERVICE]`
 
 Create containers (without starting them)
-`docker-compose create [options] [SERVICE]`
+`docker compose create [options] [SERVICE]`
 
-  * Build images before creating containers: `docker-compose create --build`
+  * Build images before creating containers: `docker compose create --build`
 
 Removes stopped service containers
-`docker-compose rm [options] [SERVICE]`
+`docker compose rm [options] [SERVICE]`
 
-  * Stop the containers, if required, before removing: `docker-compose rm --stop`
+  * Stop the containers, if required, before removing: `docker compose rm --stop`

--- a/src/docker-compose/first-side/column2.md
+++ b/src/docker-compose/first-side/column2.md
@@ -1,26 +1,26 @@
 Set the number of containers to run for an existing service
-`docker-compose scale SERVICE=NUM`
+`docker compose scale SERVICE=NUM`
 
-  * Scale the service web with 3 containers: `docker-compose scale web=3`
+  * Scale the service web with 3 containers: `docker compose scale web=3`
 
 Start existing containers for a service
-`docker-compose start SERVICE`
+`docker compose start SERVICE`
 
 Stop running containers (without removing them)
-`docker-compose stop SERVICE`
+`docker compose stop SERVICE`
 
 Pause running containers of a service
-`docker-compose pause SERVICE`
+`docker compose pause SERVICE`
 
 Unpause paused containers of a service
-`docker-compose unpause SERVICE`
+`docker compose unpause SERVICE`
 
 Run a one-time command against a service
-`docker-compose run [options] SERVICE [COMMAND]`
+`docker compose run [options] SERVICE [COMMAND]`
 
-  * Start the web service and runs bash as its command: `docker-compose run web bash`
+  * Start the web service and runs bash as its command: `docker compose run web bash`
 
 Force running containers to stop by sending a SIGKILL signal
-`docker-compose kill [options] [SERVICE]`
+`docker compose kill [options] [SERVICE]`
 
-  * Kill all containers with SIGINT signal: `docker-compose kill -s SIGINT`
+  * Kill all containers with SIGINT signal: `docker compose kill -s SIGINT`

--- a/src/docker-compose/reverse/column1.md
+++ b/src/docker-compose/reverse/column1.md
@@ -1,36 +1,36 @@
 # Manage Images
 
 Build images referenced in Compose file (without starting the containers)
-`docker-compose build [options] [SERVICE]`
+`docker compose build [options] [SERVICE]`
 
 Pull images referenced in Compose file
-`docker-compose pull [options] [SERVICE]`
+`docker compose pull [options] [SERVICE]`
 
 Push images for services to their respective registry/repository
-`docker-compose push [options] [SERVICE]`
+`docker compose push [options] [SERVICE]`
 
 # Tools
 
 Validate and view the Compose file
-`docker-compose config`
+`docker compose config`
 
 List containers
-`docker-compose ps [options] [SERVICE]`
+`docker compose ps [options] [SERVICE]`
 
 Display log output from services
-`docker-compose logs [options] [SERVICE]`
+`docker compose logs [options] [SERVICE]`
 
 Display the running processes
-`docker-compose top [SERVICE]`
+`docker compose top [SERVICE]`
 
 Stream container events for every container
-`docker-compose events [options] [SERVICE]`
+`docker compose events [options] [SERVICE]`
 
 List images used by the created containers
-`docker-compose images`
+`docker compose images`
 
 Run arbitrary commands in the containers of a service
-`docker-compose exec [options] SERVICE COMMAND`
+`docker compose exec [options] SERVICE COMMAND`
 
 Print the public port for a port binding
-`docker-compose port [options] SERVICE PRIVATE_PORT`
+`docker compose port [options] SERVICE PRIVATE_PORT`

--- a/src/docker-compose/reverse/column2.md
+++ b/src/docker-compose/reverse/column2.md
@@ -1,6 +1,6 @@
 # Compose File Example
 
-Deploying Wordpress with docker-compose :
+Deploying Wordpress with docker compose :
 
 `docker-compose.yml`
 


### PR DESCRIPTION
Docker Compose version 1 was a third-party tool, written a Python, installed to be run by the command `docker-compose` (with the hyphen).
Due to its success, it got integrated into the Docker official tool. It was the version 2, written in Go, installed to be run as a `docker` subcommand : `docker compose` (with**out** the hyphen).
As the version 1 is now deprecated since several years, and that the version 2 is the official and maintained one, I recommand to use the syntax for version 2.